### PR TITLE
-enh restructured sensor_base and sensor_helper

### DIFF
--- a/sensor_drivers/sensor_base/src/sensor_base.hpp
+++ b/sensor_drivers/sensor_base/src/sensor_base.hpp
@@ -30,31 +30,7 @@
 #define SENSOR_BASE_HPP_
 
 #include <i2c_helper.hpp>
-
-inline constexpr uint8_t kMaxAmountOfSensorBytes = 8;
-/**
- * @brief Sensordata struct contains the read sensor data with samplenum and sensortype
- * 
- * @note buffer contains the raw sensordata
- *
- */
-typedef struct SensorData {
-  uint16_t sample_num;                          /**< index / counter */
-  uint16_t sensor_id;                           /**< high byte: real sensor_id as defined in SensorType enum, low byte: subsensor (e.g. 0..8 for finger position sensor) */
-  uint16_t buffer[kMaxAmountOfSensorBytes];     /**< actual data of sensor */
-  uint8_t num_of_bytes;                         /**< number of bytes as stored in the buffer */
-} SensorData_t;
-
-enum BareSensorType {
-    NO_SENSOR,
-    UNKNOWN_SENSOR,
-    COMPRESSION_SENSOR,
-    VENTILATION_SENSOR,
-    COMPRESSION_POSITION_SENSOR,
-    HEAD_POSITION_SENSOR,
-    BODY_POSITION_SENSOR
-};
-
+#include "sensor_helper.hpp"
 
 class UniversalSensor {
  public:

--- a/sensor_drivers/sensor_base/src/sensor_helper.hpp
+++ b/sensor_drivers/sensor_base/src/sensor_helper.hpp
@@ -29,9 +29,29 @@
 #ifndef SENSOR_HELPER_HPP
 #define SENSOR_HELPER_HPP
 
-#include <sensor_base.hpp>
-#include <sensor_compression.hpp>
-#include <sensor_differentialpressure.hpp>
-#include <sensor_fingerposition.hpp>
+inline constexpr uint8_t kMaxAmountOfSensorBytes = 8;
+/**
+ * @brief Sensordata struct contains the read sensor data with samplenum and sensortype
+ *
+ * @note buffer contains the raw sensordata
+ *
+ */
+typedef struct SensorData {
+    uint16_t sample_num;                          /**< index / counter */
+    uint16_t sensor_id;                           /**< high byte: real sensor_id as defined in SensorType enum, low byte: subsensor (e.g. 0..8 for finger position sensor) */
+    uint16_t buffer[kMaxAmountOfSensorBytes];     /**< actual data of sensor */
+    uint8_t num_of_bytes;                         /**< number of bytes as stored in the buffer */
+} SensorData_t;
+
+enum BareSensorType {
+    NO_SENSOR,
+    UNKNOWN_SENSOR,
+    COMPRESSION_SENSOR,
+    VENTILATION_SENSOR,
+    COMPRESSION_POSITION_SENSOR,
+    HEAD_POSITION_SENSOR,
+    BODY_POSITION_SENSOR
+};
+
 
 #endif  // SENSOR_HELPER_HPP_


### PR DESCRIPTION
To keep the sensor_base more tidy and make good use of sensor_helper I moved all additional types etc that are used by the base but not the base itself to the helper.