### PR TITLE
make cmakelists compatible with changes in the hal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,11 @@
 
 add_library(fram_driver fram_driver/src/MB85RS2MTA.c)
 target_include_directories(fram_driver PUBLIC fram_driver/inc/)
-target_link_libraries(fram_driver Universal_hall)
+target_link_libraries(fram_driver Universal_hal)
 
 add_library(i2c_wrapper i2c_wrapper/src/i2c_helper_universal_hal.cpp)
 target_include_directories(i2c_wrapper PUBLIC i2c_wrapper/src/)
-target_link_libraries(i2c_wrapper Universal_hall)
+target_link_libraries(i2c_wrapper Universal_hal)
 
 add_library(sensor_compression sensor_drivers/sensor_compression/src/sensor_compression.cpp)
 target_include_directories(sensor_compression PUBLIC sensor_drivers/sensor_base/src/ sensor_drivers/sensor_compression/src/)


### PR DESCRIPTION
The universal hal had quite some changes to the CMakeLists. These changes were necessary to make it compatible with unit-testing as well as the addition of options (selectively disable certain modules) and spelling mistakes. 

Things changed in this PR are:
- Universal_hal lib was in the original cmakelists misspelled with two l's ("Universal_hall").  